### PR TITLE
Sets up source context.

### DIFF
--- a/tests/two_d_primitive_tests.h
+++ b/tests/two_d_primitive_tests.h
@@ -27,6 +27,7 @@ class TwoDPrimitiveTests : public TestSuite {
   static std::string MakeTestName(const BlitTest& test);
 
   struct s_CtxDma solid_lin_ctx_ {};
+  struct s_CtxDma surface_destination_ctx_ {};
 };
 
 #endif  // NXDK_PGRAPH_TESTS_2D_PRIMITIVE_TESTS_H


### PR DESCRIPTION
@abairmj got it working by setting up the surface context

![Screenshot_20211219_222013](https://user-images.githubusercontent.com/448413/146720998-26f9d855-4d9e-4a31-a79c-a69981fc387c.png)
.